### PR TITLE
Fixes the missing divide by 10 for frame delay on the single threaded write

### DIFF
--- a/rust/src/gif_handler.rs
+++ b/rust/src/gif_handler.rs
@@ -62,7 +62,7 @@ impl GifHandler {
             godot_print!("processed frame");
             let mut bytes = image.to_byte_array();
             let mut frame = Frame::from_rgba_speed(width, height, bytes.write().as_mut_slice(), self.render_quality);
-            frame.delay = self.frame_delay;
+            frame.delay = self.frame_delay / 10; // in units of 10ms
             encoder.write_frame(&frame).unwrap();
         }
     }


### PR DESCRIPTION
Missed the divide by 10 on the single thread :(

Thanks for the plugin!